### PR TITLE
Dynamic result size

### DIFF
--- a/src/generate_data.py
+++ b/src/generate_data.py
@@ -6,8 +6,8 @@ filename = 'data'
 
 data = open(filename, 'w')
 max = 0
-for number in range(100000):
-    number = random.randint(1, 1000000)
+for number in range(10):
+    number = random.randint(1, 100)
     data.write(str(number) + '\n')
     if number > max:
         max = number

--- a/src/main.c
+++ b/src/main.c
@@ -57,7 +57,11 @@ int main(int argc, char* argv[])
     }
     // If maxium is found, it is written in the result file
     if(write_to_file(max, argv[3]) == 0)
+    {
         printf("Result written to file\n");
+    }
+    else
+        return -1;
     free(data);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@ unsigned int count_lines(const char *filename);
 int* read_file_to_array(const char* filename, unsigned int* line_count);
 void write_to_file(int max, const char* filename);
 int convert_array_to_int(char* number, int size);
-char* convert_int_to_array(int num);
+char* convert_int_to_array(int num, int* size);
 
 int main(int argc, char* argv[])
 {
@@ -115,8 +115,9 @@ void write_to_file(int max, const char* filename)
     int file;
     if ((file = open(filename, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR | S_IROTH)) != -1)
     {
-        char* max_str = convert_int_to_array(max);
-        write(file, max_str, NUM_MAX_LENGTH);
+        int size = 0;
+        char* max_str = convert_int_to_array(max, &size);
+        write(file, max_str, size);
         write(file, "\n", 1);
         free(max_str);
     }
@@ -139,19 +140,18 @@ int convert_array_to_int(char* number, int size)
     return result;
 }
 
-char* convert_int_to_array(int num)
+char* convert_int_to_array(int num, int* size)
 {
-    int size = 0;
     int num_copy = num;
     while (num_copy > 0)
     {
         num_copy /= 10;
-        size++;
+        (*size)++;
     }
 
-    char *array = calloc(size, sizeof(char));
+    char *array = calloc(*size, sizeof(char));
 
-    for (int i = size - 1; i >= 0; i--)
+    for (int i = *size - 1; i >= 0; i--)
     {
         array[i] = '0' + (num % 10);
         num /= 10;

--- a/src/main.c
+++ b/src/main.c
@@ -15,7 +15,7 @@
 
 unsigned int count_lines(const char *filename);
 int* read_file_to_array(const char* filename, unsigned int* line_count);
-void write_to_file(int max, const char* filename);
+int write_to_file(int max, const char* filename);
 int convert_array_to_int(char* number, int size);
 char* convert_int_to_array(int num, int* size);
 
@@ -56,8 +56,8 @@ int main(int argc, char* argv[])
         return -1;
     }
     // If maxium is found, it is written in the result file
-    write_to_file(max, argv[3]);
-
+    if(write_to_file(max, argv[3]) == 0)
+        printf("Result written to file\n");
     free(data);
 }
 
@@ -110,8 +110,14 @@ int* read_file_to_array(const char* filename, unsigned int* line_count)
 }
 
 // write a number to a file
-void write_to_file(int max, const char* filename)
+int write_to_file(int max, const char* filename)
 {
+    int ret = unlink(filename);
+    if (ret == -1)
+    {
+        fprintf(stderr, "Can't open destination file, check permissions\n");
+        return -1;
+    }
     int file;
     if ((file = open(filename, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR | S_IROTH)) != -1)
     {
@@ -120,10 +126,12 @@ void write_to_file(int max, const char* filename)
         write(file, max_str, size);
         write(file, "\n", 1);
         free(max_str);
+        return 0;
     }
     else
     {
         fprintf(stderr, "Can't open destination file, check permissions\n");
+        return -1;
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -56,7 +56,8 @@ int main(int argc, char* argv[])
         return -1;
     }
     // If maxium is found, it is written in the result file
-    if(write_to_file(max, argv[3]) == 0)
+    int ret = write_to_file(max, argv[3]);
+    if(ret == 0)
     {
         printf("Result written to file\n");
     }
@@ -117,7 +118,7 @@ int* read_file_to_array(const char* filename, unsigned int* line_count)
 int write_to_file(int max, const char* filename)
 {
     int ret = unlink(filename);
-    if (ret == -1)
+    if (ret == -1 && errno != ENOENT)
     {
         fprintf(stderr, "Can't open destination file, check permissions\n");
         return -1;

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+src/generate_data.py
+
+./Max data 4 result 2> error.log
+
+cat result


### PR DESCRIPTION
Before the modification, if the maximum number was less than 6 digits, some weird characters were added in the resulting file. It now works with all size (equal or less than NUM_MAX_SIZE).

New syscalls used : unlink() to delete result file before writing in it.